### PR TITLE
広告表示オプションのベストプラクティスページのmarkdown崩れの修正

### DIFF
--- a/bestpractice/ja/addisplayoption.md
+++ b/bestpractice/ja/addisplayoption.md
@@ -459,6 +459,7 @@ No                | CALL_PHONE_NUMBER
 ##### ※FeedItemの更新について
 更新時にfeedItemAttributeを指定するとすべて上書きされ、未指定のフィードアイテムの属性情報は削除されます。
 また、下記の場合のみfeedAttributeValueに空文字を指定することで削除が可能です。
+
 placeholderType   | placeholderField
 ----------------- | --------------------
 QUICKLINK         | ADVANCED_MOBILE_URL


### PR DESCRIPTION
markdownが崩れて表示されるページがあったため修正しました。

## BEFORE

<img width="1152" alt="スクリーンショット 2021-09-10 14 25 09" src="https://user-images.githubusercontent.com/296615/132804115-a818272c-23ea-4c6c-9941-f5a45d7b95ca.png">

## AFTER

<img width="1105" alt="スクリーンショット 2021-09-10 14 26 07" src="https://user-images.githubusercontent.com/296615/132804137-29b4e7e9-7703-4310-9a4d-bd369c951cf4.png">
